### PR TITLE
Site form converts address to longitude and latitude for gmaps

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,9 @@ gem "omniauth-google-oauth2"
 gem "factory_girl_rails"
 gem 'faker'
 
+# Geocoder for sites longitude and latitude conversion
+gem 'geocoder'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platform: :mri

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,6 +73,7 @@ GEM
     ffi (1.9.14)
     figaro (1.1.1)
       thor (~> 0.14)
+    geocoder (1.3.7)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
     hashie (3.4.4)
@@ -221,6 +222,7 @@ DEPENDENCIES
   factory_girl_rails
   faker
   figaro
+  geocoder
   jbuilder (~> 2.5)
   jquery-rails
   listen (~> 3.0.5)

--- a/app/assets/javascripts/maps.js
+++ b/app/assets/javascripts/maps.js
@@ -8,7 +8,6 @@ $(document).ready(function(){
                 initMap(data);
               }
   });
-
 });
 
 function initMap(data){

--- a/app/controllers/dashboard/sites_controller.rb
+++ b/app/controllers/dashboard/sites_controller.rb
@@ -1,0 +1,33 @@
+class Dashboard::SitesController < ApplicationController
+
+  def show
+  end
+
+  def new
+    @site = current_user.sites.new
+  end
+
+  def create
+    @site = current_user.sites.new(site_params)
+    if @site.save
+      flash[:success] = "You created a new site!"
+      redirect_to dashboard_path
+    else
+      flash.now[:warning] = @site.errors.full_messages.join(", ")
+      render :new
+    end
+  end
+
+  private
+
+  def site_params
+    params.require(:site).permit(:name,
+                                 :description,
+                                 :street,
+                                 :city,
+                                 :state,
+                                 :zip,
+                                 :longitude,
+                                 :latitude)
+  end
+end

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,0 +1,6 @@
+class DashboardController < ApplicationController
+
+  def show
+    @sites = current_user.sites
+  end
+end

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -1,5 +1,0 @@
-class DashboardsController < ApplicationController
-
-  def show
-  end
-end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -1,3 +1,17 @@
 class Site < ApplicationRecord
   belongs_to :user
+
+  validates :street, uniqueness: { scope: [:city, :state, :zip] }, on: :create
+  validates :street, presence: true
+  validates :city, presence: true
+  validates :state, presence: true
+  validates :zip, presence: true
+
+  after_create :convert_address_to_long_lat
+
+  def convert_address_to_long_lat
+    formatted_address = "#{street}, #{city}, #{state} #{zip}"
+    long_lat = Geocoder.coordinates(formatted_address)
+    update(longitude: long_lat[1], latitude: long_lat[0])
+  end
 end

--- a/app/views/dashboard/show.html.erb
+++ b/app/views/dashboard/show.html.erb
@@ -1,0 +1,9 @@
+<h1 class="text-center">Health Dashboard</h1>
+
+<ul>
+  <% @sites.each do |site| %>
+    <li><%= site.name %></li>
+  <% end %>
+</ul>
+
+<%= link_to "Create a New Site", new_dashboard_site_path, class: "btn btn-primary" %>

--- a/app/views/dashboard/sites/new.html.erb
+++ b/app/views/dashboard/sites/new.html.erb
@@ -1,0 +1,53 @@
+<div class="col-md-offset-2 col-md-8">
+  <div class="panel panel-default">
+    <div class="panel-heading">
+      <h2 class="panel-title">Create a New Hives Site</h2>
+    </div>
+    <div class="panel-body">
+      <%= form_for [:dashboard, @site] do |f| %>
+        <div class="row">
+          <div class="form-group col-md-6">
+            <%= f.label :name %>
+            <%= f.text_field :name, class: "form-control" %>
+          </div>
+        </div>
+
+        <div class="form-group">
+          <%= f.label :description %>
+          <%= f.text_area :description, class: "form-control", rows: 3 %>
+        </div>
+
+        <p>Location of your hives:</p>
+        <div class="row">
+          <div class="form-group col-md-6">
+            <%= f.label :street %>
+            <%= f.text_field :street, class: "form-control" %>
+          </div>
+        </div>
+
+        <div class="row">
+          <div class="form-group col-md-4">
+            <%= f.label :city %>
+            <%= f.text_field :city, class: "form-control" %>
+          </div>
+        </div>
+
+        <div class="row">
+          <div class="form-group col-md-1">
+            <%= f.label :state %>
+            <%= f.text_field :state, class: "form-control" %>
+          </div>
+        </div>
+
+        <div class="row">
+          <div class="form-group col-md-2">
+            <%= f.label :zip %>
+            <%= f.text_field :zip, class: "form-control" %>
+          </div>
+        </div>
+
+        <%= f.submit "Create Site", class: "btn btn-primary" %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -1,1 +1,0 @@
-<h1 class="text-center">Health Dashboard</h1>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,11 +9,18 @@
   <body>
     <%= render "shared/navbar" %>
 
-    <%= yield %>
+    <div class="container-fluid">
+      <% flash.each do |type, message| %>
+        <div class="alert alert-<%= type %> text-center alert-dismissible" role="alert">
+          <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+            <span aria-hidden="true">&times;</span></button>
+          <%= sanitize(message) %>
+        </div>
+      <% end %>
+      
+      <%= yield %>
+    </div>
   </body>
 
   <%= javascript_include_tag 'application' %>
-  <script async defer
-      src="https://maps.googleapis.com/maps/api/js?key=<%=ENV['GOOGLE_MAPS_API']%>">
-  </script>
 </html>

--- a/app/views/sites/index.html.erb
+++ b/app/views/sites/index.html.erb
@@ -2,3 +2,7 @@
   <div id="all-sites-map">
   </div>
 </div>
+
+<script 
+    src="https://maps.googleapis.com/maps/api/js?key=<%=ENV['GOOGLE_MAPS_API']%>">
+</script>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,11 @@ Rails.application.routes.draw do
 
   resources :sites, only: [:index]
 
-  resource :dashboard, only: [:show]
+  resource :dashboard, only: [:show], :controller => "dashboard"
+
+  namespace :dashboard do
+    resources :sites, only: [:show, :new, :create, :edit, :update]
+  end
 
   get '/auth/google_oauth2', as: :google_login
   get '/auth/google_oauth2/callback', to: "sessions#create"


### PR DESCRIPTION
User can create a site that they own
User inputs address for new site and is converted to latitude and longitude points for google maps API
Added geocoder to convert address to long and lat coordinates
Changed dashboard controller name to singular
Added site model validations for form
Added flash message box
